### PR TITLE
docs: update events emitTo since

### DIFF
--- a/tooling/api/src/event.ts
+++ b/tooling/api/src/event.ts
@@ -193,7 +193,6 @@ async function emit(event: string, payload?: unknown): Promise<void> {
  * @param event Event name. Must include only alphanumeric characters, `-`, `/`, `:` and `_`.
  * @param payload Event payload.
  *
- * @since 1.0.0
  */
 async function emitTo(
   target: EventTarget | string,

--- a/tooling/api/src/event.ts
+++ b/tooling/api/src/event.ts
@@ -193,6 +193,7 @@ async function emit(event: string, payload?: unknown): Promise<void> {
  * @param event Event name. Must include only alphanumeric characters, `-`, `/`, `:` and `_`.
  * @param payload Event payload.
  *
+ * @since 2.0.0
  */
 async function emitTo(
   target: EventTarget | string,


### PR DESCRIPTION
The generated api on the v2 docs incorrectly state that EmitTo was introduced in v1 when in reality they are new to v2

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated documentation for the `emitTo` function. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->